### PR TITLE
feat(parsergen): add generated Python syntax target

### DIFF
--- a/tools/parsergen/PYTHON_TARGET.md
+++ b/tools/parsergen/PYTHON_TARGET.md
@@ -1,0 +1,17 @@
+# Python target status
+
+The first Python target milestone generates a standalone syntax recognizer from
+the existing canonical Parser IR and decision DAG. It uses an explicit task
+stack, so EBNF repetition and direct right recursion do not consume the Python
+call stack.
+
+The current generated `GeneratedParser.parse()` validates a token stream and
+returns no semantic value. This is intentionally an intermediate spike, not the
+completed Python target.
+
+The next milestone must generate the AST model automatically from the grammar's
+semantic declarations. Distinct grammar node alternatives should normally
+become distinct Python classes; a separate string discriminator such as
+`node_type` is not required. The target must then execute semantic Parser IR
+operations and return instances of those generated classes, including source
+spans needed for source-to-source transformations.

--- a/tools/parsergen/src/parsergen/parser_ir.py
+++ b/tools/parsergen/src/parsergen/parser_ir.py
@@ -57,6 +57,7 @@ from .source_model import (
     SourceProduction,
     SourceRepeat,
     SourceSequence,
+    SourceValue,
 )
 
 
@@ -358,6 +359,54 @@ def build_parser_ir(
         else entrypoint_productions
     )
     parser_ir = _ParserIrBuilder(
+        source,
+        lowering,
+        analysis,
+        frozenset(selected_names),
+        protected_entrypoints,
+    ).build()
+    from .parser_ir_optimization import optimize_parser_ir
+
+    return optimize_parser_ir(parser_ir)
+
+
+def build_syntax_parser_ir(
+    source: SourceGrammar,
+    lowering: LoweringResult,
+    resolved: ResolvedGrammar,
+    analysis: AnalysisResult,
+    *,
+    production_names: Collection[str] | None = None,
+    entrypoint_productions: Collection[str] | None = None,
+) -> ParserIr:
+    """Build canonical control-flow IR while deliberately discarding values."""
+    if any(item.severity is Severity.ERROR for item in lowering.diagnostics):
+        raise ValueError("source grammar has EBNF validation errors")
+    if lower_source_grammar(source) != lowering:
+        raise ValueError("source grammar does not match lowering result")
+    reparsed = resolve_grammar(lowering.grammar)
+    if reparsed.grammar is None or reparsed.grammar != resolved:
+        raise ValueError("lowered grammar does not match resolved grammar")
+    if analysis._resolved_grammar is not resolved:
+        raise ValueError("analysis is not bound to the resolved grammar")
+    selected_names = _selected_production_names(source, production_names)
+    required_decisions = _required_decision_productions(
+        lowering,
+        frozenset(selected_names),
+    )
+    conflicts = tuple(
+        conflict
+        for conflict in find_canonical_select_conflicts(resolved, analysis)
+        if conflict.production in required_decisions
+    )
+    if conflicts:
+        raise ValueError("overlapping canonical SELECT prevents Parser IR")
+    protected_entrypoints = frozenset(
+        selected_names
+        if entrypoint_productions is None
+        else entrypoint_productions
+    )
+    parser_ir = _SyntaxParserIrBuilder(
         source,
         lowering,
         analysis,
@@ -1213,6 +1262,137 @@ class _ParserIrBuilder:
         decision = CanonicalDecision(source, build_decision_dag(source))
         self._decisions[key] = decision
         return decision
+
+
+class _SyntaxParserIrBuilder(_ParserIrBuilder):
+    """Builds Parser IR for targets that validate syntax without AST values."""
+
+    def _sequence(self, sequence: SourceSequence) -> tuple[Operation, ...]:
+        result: list[Operation] = []
+        for item in sequence.items:
+            if isinstance(item, (Action, SourceConstructor, SourceConstantBinding)):
+                continue
+            if isinstance(item, SourceBinding):
+                result.extend(self._syntax_value(item.value))
+            else:
+                result.extend(self._syntax_value(item))
+        return tuple(result)
+
+    def _syntax_value(self, value: SourceValue | SourceItem) -> tuple[Operation, ...]:
+        if isinstance(value, SourceGroup):
+            construct = self._construct(value.span, LoweredConstructKind.GROUP)
+            return (
+                Dispatch(
+                    self._decision(construct.production),
+                    self._syntax_branches(value, construct.production),
+                    value.span,
+                ),
+            )
+        if isinstance(value, SourceOptional):
+            construct = self._construct(value.span, LoweredConstructKind.OPTIONAL)
+            branches = self._syntax_primary_branches(
+                value.body,
+                construct.production,
+            )
+            return (
+                OptionalBranch(
+                    self._decision(
+                        construct.production,
+                        exit_alternative=len(branches) + 1,
+                    ),
+                    branches,
+                    (),
+                    value.span,
+                ),
+            )
+        if isinstance(value, SourceRepeat):
+            return self._syntax_repeat(value)
+        assert isinstance(value, (Terminal, Lexeme, Constant, IdentifierRef, NonterminalCall))
+        return (DiscardSymbol(value, value.span),)
+
+    def _syntax_repeat(self, repeat: SourceRepeat) -> tuple[Operation, ...]:
+        kind = (
+            LoweredConstructKind.STAR
+            if repeat.kind.value == "star"
+            else LoweredConstructKind.PLUS
+        )
+        construct = self._construct(repeat.span, kind)
+        branches = self._syntax_primary_branches(
+            repeat.body,
+            construct.production,
+        )
+        result: list[Operation] = []
+        decision_production = construct.production
+        if kind is LoweredConstructKind.PLUS:
+            if len(branches) == 1:
+                result.extend(branches[0].operations)
+            else:
+                result.append(
+                    Dispatch(
+                        self._decision(construct.production),
+                        branches,
+                        repeat.span,
+                    )
+                )
+            assert construct.tail_production is not None
+            decision_production = construct.tail_production
+            branches = tuple(
+                BranchIr(
+                    AlternativeOutcome(
+                        decision_production,
+                        branch.outcome.alternative,
+                    ),
+                    branch.operations,
+                    None,
+                    branch.source_span,
+                )
+                for branch in branches
+            )
+        result.append(
+            RepeatLoop(
+                self._decision(
+                    decision_production,
+                    exit_alternative=len(branches) + 1,
+                ),
+                branches,
+                repeat.span,
+            )
+        )
+        return tuple(result)
+
+    def _syntax_primary_branches(
+        self,
+        primary: SourcePrimary,
+        decision_production: str,
+    ) -> tuple[BranchIr, ...]:
+        if isinstance(primary, SourceGroup):
+            return self._syntax_branches(primary, decision_production)
+        return (
+            BranchIr(
+                AlternativeOutcome(decision_production, 1),
+                self._syntax_value(primary),
+                None,
+                primary.span,
+            ),
+        )
+
+    def _syntax_branches(
+        self,
+        group: SourceGroup,
+        decision_production: str,
+    ) -> tuple[BranchIr, ...]:
+        return tuple(
+            BranchIr(
+                AlternativeOutcome(
+                    decision_production,
+                    alternative.index + 1,
+                ),
+                self._sequence(alternative.body),
+                None,
+                alternative.span,
+            )
+            for alternative in group.alternatives
+        )
 
 
 def _produces_transparent_value(operation: Operation) -> bool:

--- a/tools/parsergen/src/parsergen/python_codegen.py
+++ b/tools/parsergen/src/parsergen/python_codegen.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pprint import pformat
+from typing import Mapping
+
+from .decision_dag import (
+    CommitAlternative,
+    ExitDecision,
+    ImmediateError,
+    LookaheadDecision,
+)
+from .model import Constant, IdentifierRef, Lexeme, NonterminalCall, SyntaxSymbol, Terminal
+from .parser_ir import (
+    CanonicalDecision,
+    ConsumeKnownSymbol,
+    DiscardSymbol,
+    Dispatch,
+    Operation,
+    OptionalBranch,
+    ParseSymbol,
+    ParserIr,
+    RepeatLoop,
+    ResolvedRegion,
+)
+from .source_model import SourceGrammar
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratedPythonParser:
+    module_text: str
+
+
+def generate_python_parser(
+    source: SourceGrammar,
+    parser_ir: ParserIr,
+    entrypoints: Mapping[str, str],
+) -> GeneratedPythonParser:
+    """Generate a standalone syntax recognizer from canonical Parser IR.
+
+    The current milestone deliberately emits no semantic values. A complete
+    Python target must additionally generate AST classes from grammar semantic
+    declarations and execute the corresponding semantic Parser IR operations.
+    """
+    return GeneratedPythonParser(
+        _PythonGenerator(source, parser_ir, entrypoints).generate()
+    )
+
+
+class _PythonGenerator:
+    def __init__(
+        self,
+        source: SourceGrammar,
+        parser_ir: ParserIr,
+        entrypoints: Mapping[str, str],
+    ) -> None:
+        self.source = source
+        self.parser_ir = parser_ir
+        self.entrypoints = dict(entrypoints)
+        self.identifier_types = {
+            item.name: item.token_types for item in source.identifier_definitions
+        }
+        self.decisions: list[tuple[object, ...]] = []
+        self.decision_ids: dict[int, int] = {}
+
+    def generate(self) -> str:
+        self._validate()
+        productions = {
+            production.name: (
+                None
+                if production.decision is None
+                else self._decision_id(production.decision),
+                tuple(
+                    (
+                        alternative.index + 1,
+                        self._operations(alternative.operations),
+                    )
+                    for alternative in production.alternatives
+                ),
+            )
+            for production in self.parser_ir.productions
+        }
+        decisions = tuple(self.decisions)
+        return _MODULE_TEMPLATE.format(
+            entrypoints=pformat(self.entrypoints, width=100, sort_dicts=True),
+            productions=pformat(productions, width=100, sort_dicts=True),
+            decisions=pformat(decisions, width=100, sort_dicts=True),
+        )
+
+    def _validate(self) -> None:
+        if self.source != self.parser_ir.source_grammar:
+            raise ValueError("source grammar does not match Parser IR")
+        if not self.entrypoints:
+            raise ValueError("entrypoint mapping must not be empty")
+        productions = {item.name for item in self.parser_ir.productions}
+        for name, production in self.entrypoints.items():
+            if not name:
+                raise ValueError("entrypoint name must not be empty")
+            if production not in productions:
+                raise ValueError(
+                    f"entrypoint {name!r} references unknown production {production!r}"
+                )
+
+    def _decision_id(self, decision: CanonicalDecision) -> int:
+        key = id(decision)
+        existing = self.decision_ids.get(key)
+        if existing is not None:
+            return existing
+        identifier = len(self.decisions)
+        self.decision_ids[key] = identifier
+        self.decisions.append(())
+        nodes: list[tuple[object, ...]] = []
+        for node in decision.dag.nodes:
+            if isinstance(node, LookaheadDecision):
+                nodes.append(
+                    (
+                        "look",
+                        node.offset,
+                        node.expected,
+                        tuple(
+                            (edge.predicate.token_types, edge.target)
+                            for edge in node.edges
+                        ),
+                    )
+                )
+            elif isinstance(node, CommitAlternative):
+                nodes.append(
+                    (
+                        "commit",
+                        node.outcome.production,
+                        node.outcome.alternative,
+                    )
+                )
+            elif isinstance(node, ExitDecision):
+                nodes.append(
+                    (
+                        "exit",
+                        node.outcome.production,
+                        node.outcome.alternative,
+                    )
+                )
+            elif isinstance(node, ImmediateError):
+                nodes.append(("error", node.expected))
+            else:
+                raise TypeError(type(node))
+        self.decisions[identifier] = (decision.dag.root, tuple(nodes))
+        return identifier
+
+    def _operations(
+        self,
+        operations: tuple[Operation, ...],
+    ) -> tuple[tuple[object, ...], ...]:
+        rendered: list[tuple[object, ...]] = []
+        for operation in operations:
+            if isinstance(operation, ResolvedRegion):
+                rendered.extend(self._operations(operation.operations))
+            elif isinstance(operation, (DiscardSymbol, ParseSymbol)):
+                rendered.append(self._symbol(operation.symbol))
+            elif isinstance(operation, ConsumeKnownSymbol):
+                rendered.append(self._symbol(operation.symbol))
+            elif isinstance(operation, Dispatch):
+                rendered.append(
+                    (
+                        "dispatch",
+                        self._decision_id(operation.decision),
+                        self._branches(operation.branches),
+                    )
+                )
+            elif isinstance(operation, OptionalBranch):
+                if operation.exit_operations:
+                    raise ValueError(
+                        "syntax-only optional must not contain semantic exit operations"
+                    )
+                rendered.append(
+                    (
+                        "optional",
+                        self._decision_id(operation.decision),
+                        self._branches(operation.branches),
+                    )
+                )
+            elif isinstance(operation, RepeatLoop):
+                rendered.append(
+                    (
+                        "repeat",
+                        self._decision_id(operation.decision),
+                        self._branches(operation.branches),
+                    )
+                )
+            else:
+                raise ValueError(
+                    "Python syntax target does not support semantic operation "
+                    f"{type(operation).__name__}"
+                )
+        return tuple(rendered)
+
+    def _branches(self, branches) -> tuple[tuple[object, ...], ...]:
+        return tuple(
+            (
+                (branch.outcome.production, branch.outcome.alternative),
+                None
+                if branch.path_facts is None
+                else tuple(
+                    (fact.offset, fact.predicate.token_types)
+                    for fact in branch.path_facts
+                ),
+                self._operations(branch.operations),
+            )
+            for branch in branches
+        )
+
+    def _symbol(self, symbol: SyntaxSymbol) -> tuple[object, ...]:
+        if isinstance(symbol, NonterminalCall):
+            return ("call", symbol.name)
+        if isinstance(symbol, Terminal):
+            expected = (symbol.token_type,)
+        elif isinstance(symbol, Lexeme):
+            expected = (symbol.text,)
+        elif isinstance(symbol, Constant):
+            expected = (symbol.token_type,)
+        elif isinstance(symbol, IdentifierRef):
+            try:
+                expected = self.identifier_types[symbol.name]
+            except KeyError as error:
+                raise ValueError(
+                    f"unknown identifier definition {symbol.name!r}"
+                ) from error
+        else:
+            raise TypeError(type(symbol))
+        return ("consume", tuple(expected))
+
+
+_MODULE_TEMPLATE = '''from __future__ import annotations
+
+
+ENTRYPOINTS = {entrypoints}
+PRODUCTIONS = {productions}
+DECISIONS = {decisions}
+
+
+class GeneratedParseError(ValueError):
+    def __init__(self, position, actual, expected):
+        self.position = position
+        self.actual = actual
+        self.expected = tuple(expected)
+        super().__init__(
+            f"unexpected {{actual!r}} at token {{position}}; expected {{self.expected!r}}"
+        )
+
+
+class GeneratedParser:
+    def parse(self, tokens, entrypoint):
+        try:
+            production = ENTRYPOINTS[entrypoint]
+        except KeyError as error:
+            raise ValueError(f"unknown entrypoint {{entrypoint!r}}") from error
+        self.tokens = tokens if hasattr(tokens, "__getitem__") else tuple(tokens)
+        self.position = 0
+        tasks = [("call", production)]
+        while tasks:
+            task = tasks.pop()
+            kind = task[0]
+            if kind == "call":
+                decision, alternatives = PRODUCTIONS[task[1]]
+                if decision is None:
+                    operations = alternatives[0][1]
+                else:
+                    leaf = self._decide(decision)
+                    if leaf[0] != "commit":
+                        self._raise(())
+                    operations = next(
+                        body for number, body in alternatives if number == leaf[2]
+                    )
+                tasks.extend(reversed(operations))
+            elif kind == "consume":
+                actual = self._lookahead(0)
+                if actual not in task[1]:
+                    self._raise(task[1])
+                self.position += 1
+            elif kind in ("dispatch", "optional", "repeat"):
+                leaf = self._decide(task[1])
+                if leaf[0] == "exit":
+                    if kind == "dispatch":
+                        self._raise(())
+                    continue
+                if leaf[0] != "commit":
+                    self._raise(())
+                operations = self._branch(task[2], leaf)
+                if kind == "repeat":
+                    tasks.append(task)
+                tasks.extend(reversed(operations))
+            else:
+                raise RuntimeError(f"unknown generated parser operation {{kind!r}}")
+        if self.position != len(self.tokens):
+            self._raise(("$",))
+
+    def _decide(self, decision):
+        root, nodes = DECISIONS[decision]
+        node = nodes[root]
+        while node[0] == "look":
+            actual = self._lookahead(node[1])
+            target = next(
+                (target for token_types, target in node[3] if actual in token_types),
+                None,
+            )
+            if target is None:
+                self._raise(node[2])
+            node = nodes[target]
+        if node[0] == "error":
+            self._raise(node[1])
+        return node
+
+    def _branch(self, branches, leaf):
+        outcome = (leaf[1], leaf[2])
+        for branch_outcome, facts, operations in branches:
+            if branch_outcome != outcome:
+                continue
+            if facts is None or all(
+                self._lookahead(offset) in token_types
+                for offset, token_types in facts
+            ):
+                return operations
+        raise RuntimeError(f"decision outcome has no generated branch: {{outcome!r}}")
+
+    def _lookahead(self, offset):
+        index = self.position + offset
+        if index >= len(self.tokens):
+            return "$"
+        token = self.tokens[index]
+        return token if isinstance(token, str) else token.type
+
+    def _raise(self, expected):
+        raise GeneratedParseError(
+            self.position,
+            self._lookahead(0),
+            expected,
+        )
+'''

--- a/tools/parsergen/tests/test_python_codegen.py
+++ b/tools/parsergen/tests/test_python_codegen.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from parsergen.analysis import compute_analysis
+from parsergen.grammar_parser import parse_grammar
+from parsergen.parser_ir import RepeatLoop, build_syntax_parser_ir
+from parsergen.python_codegen import generate_python_parser
+from parsergen.resolver import resolve_grammar
+
+
+@dataclass(frozen=True)
+class Token:
+    type: str
+    text: str = ""
+    start: int = 0
+    end: int = 0
+
+
+def _generate(source: str, *, k: int = 1):
+    parsed = parse_grammar(source, "grammar.txt")
+    assert parsed.diagnostics == ()
+    assert parsed.grammar is not None
+    assert parsed.source_grammar is not None
+    assert parsed.lowering is not None
+    resolved = resolve_grammar(parsed.grammar)
+    assert resolved.diagnostics == ()
+    assert resolved.grammar is not None
+    analysis = compute_analysis(resolved.grammar, k, ("S",))
+    parser_ir = build_syntax_parser_ir(
+        parsed.source_grammar,
+        parsed.lowering,
+        resolved.grammar,
+        analysis,
+        entrypoint_productions=("S",),
+    )
+    generated = generate_python_parser(
+        parsed.source_grammar,
+        parser_ir,
+        {"start": "S"},
+    )
+    namespace: dict[str, object] = {}
+    exec(compile(generated.module_text, "<generated-parser>", "exec"), namespace)
+    return parser_ir, generated, namespace
+
+
+def test_generates_dag_parser_and_repeat_loop_as_iterative_python() -> None:
+    parser_ir, generated, namespace = _generate(
+        "<S> ::= ITEM (',' ITEM)*"
+    )
+
+    assert any(
+        isinstance(operation, RepeatLoop)
+        for production in parser_ir.productions
+        for alternative in production.alternatives
+        for operation in alternative.operations
+    )
+    assert "while tasks:" in generated.module_text
+    parser = namespace["GeneratedParser"]()
+    parser.parse(
+        [Token("ITEM"), *[token for _ in range(5_000) for token in (Token(","), Token("ITEM"))]],
+        "start",
+    )
+
+
+def test_generated_parser_trampolines_direct_right_recursion() -> None:
+    _, _, namespace = _generate("<S> ::= ITEM <S>?")
+    parser = namespace["GeneratedParser"]()
+
+    parser.parse([Token("ITEM") for _ in range(5_000)], "start")
+
+
+def test_generated_parser_uses_k2_decision_dag() -> None:
+    _, _, namespace = _generate(
+        "<S> ::= 'a' 'b' | 'a' 'c'",
+        k=2,
+    )
+    parser = namespace["GeneratedParser"]()
+
+    parser.parse([Token("a"), Token("c")], "start")
+
+
+def test_generated_parser_reports_position_actual_and_expected() -> None:
+    _, _, namespace = _generate("<S> ::= ITEM ',' ITEM")
+    parser = namespace["GeneratedParser"]()
+    error_type = namespace["GeneratedParseError"]
+
+    with pytest.raises(error_type) as caught:
+        parser.parse([Token("ITEM"), Token(";")], "start")
+
+    assert caught.value.position == 1
+    assert caught.value.actual == ";"
+    assert caught.value.expected == (",",)


### PR DESCRIPTION
## Summary
- build syntax-only Parser IR while reusing the existing lowering, canonical SELECT, and decision DAG pipeline
- generate a standalone Python recognizer with an explicit task stack for EBNF loops and right recursion
- cover iterative repetition, 5,000-level right recursion, LL(2) decisions, and diagnostics
- document automatic Python AST class generation from grammar semantics as the next milestone

## Verification
- 586 passed, 1 skipped, 27756 subtests passed
- runtime corpus consumer: 989/989 selected ZUP modules parsed